### PR TITLE
Make several methods public

### DIFF
--- a/lib/blockscore/connection.rb
+++ b/lib/blockscore/connection.rb
@@ -17,8 +17,6 @@ module BlockScore
       request(:delete, path, nil)
     end
 
-    private
-
     def get(path, params)
       request(:get, encode_path_params(path, params), nil)
     end
@@ -30,6 +28,8 @@ module BlockScore
     def patch(path, params)
       request(:patch, path, params.to_json)
     end
+
+    private
 
     def request(method, final_endpoint, params)
       begin


### PR DESCRIPTION
Ruby 2.4 removes the ability to forward to private/protected methods. In
order to maintain the existing functionality, this commit makes several
delegated methods public.